### PR TITLE
TLS endpoints enabling HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ with .mbtiles extension
 
 --key, --tls-private-key: Path to .pem Private Key
 
+If --cert and --key are both set, content will be served over TLS (HTTPS) and unecrypted HTTP will return nothing or a
+TLS error response
+
 # Methods
 
 The following methods are available via the HTTP API. The other methods in the [app definition](diglet/app.go) are for use with WS

--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ Here are some neat things that diglet does
 --mbtiles: Path to local directory containing mbtiles files. NOTE only serves files
 with .mbtiles extension
 
---port: default is 8080
+--port: Default is 8080
+
+--cert, --tls-certificate: Path to .pem TLS Certificate. Both cert & key required to serve HTTPS
+
+--key, --tls-private-key: Path to .pem Private Key
 
 # Methods
 

--- a/burrow/routes.go
+++ b/burrow/routes.go
@@ -82,9 +82,6 @@ type HTTPHandler func(w http.ResponseWriter, r *http.Request) (msg *ResponseMess
 
 func (handle HTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// info("Request - %v", r)
-	if r.TLS == nil {
-		info("NO TLS")
-	}
 	response := handle(w, r)
 	if response != nil {
 		content, err := response.Marshal()

--- a/burrow/routes.go
+++ b/burrow/routes.go
@@ -82,6 +82,9 @@ type HTTPHandler func(w http.ResponseWriter, r *http.Request) (msg *ResponseMess
 
 func (handle HTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// info("Request - %v", r)
+	if r.TLS == nil {
+		info("NO TLS")
+	}
 	response := handle(w, r)
 	if response != nil {
 		content, err := response.Marshal()

--- a/burrow/server.go
+++ b/burrow/server.go
@@ -8,12 +8,14 @@ import (
 )
 
 type App struct {
-	Prefix  string
-	Name    string
-	Methods []Method
-	Debug   bool
-	Port    string
-	Router  *mux.Router
+	Prefix         string
+	Name           string
+	Methods        []Method
+	Debug          bool
+	Port           string
+	Router         *mux.Router
+	TLSCertificate *string
+	TLSPrivateKey  *string
 }
 
 func (app *App) Run() error {
@@ -24,6 +26,12 @@ func (app *App) Run() error {
 	routes.Subrouter(r)
 	app.Router = r
 	return app.start()
+}
+
+func (app *App) RunTLS(cert, key *string) error {
+	app.TLSCertificate = cert
+	app.TLSPrivateKey = key
+	return app.Run()
 }
 
 func NewApp(name string) *App {
@@ -37,17 +45,58 @@ func NewApp(name string) *App {
 
 func (app *App) start() (err error) {
 	info("%s used Burrow!", app.Name)
-
 	app.mountStatic()
 	http.Handle("/", app.Router)
-
-	info("Now serving on port :%s", app.Port)
-	err = http.ListenAndServe(":"+app.Port, nil)
+	if app.hasCerts() {
+		err = app.serveTLS()
+	} else {
+		err = app.serve()
+	}
 	check(err)
 	return
+}
+
+func (app *App) serve() (err error) {
+	info("Now serving unencrypted HTTP traffic on port :%s", app.Port)
+	return http.ListenAndServe(app.GetPort(), nil)
+}
+
+func (app *App) serveTLS() (err error) {
+	port := app.GetPort()
+	cert := *app.TLSCertificate
+	key := *app.TLSPrivateKey
+	info("Now serving encrypted TLS traffic on port :%s", app.Port)
+	return http.ListenAndServeTLS(port, cert, key, nil)
+	/*
+		// This would be if we wanted to redirect http traffic to https
+		errs := make(chan error)
+		go func() {
+			errs <- http.ListenAndServeTLS(":1443", cert, key, nil)
+		}()
+		go func() {
+			redir := func(w http.ResponseWriter, r *http.Request) {
+				// Don't think this works
+				r.URL.Scheme = "https://"
+				http.Redirect(w, r, r.URL.String(), http.StatusMovedPermanently)
+			}
+			errs <- http.ListenAndServe(":8080", http.HandlerFunc(redir))
+		}()
+		select {
+		case err = <-errs:
+			return
+		}
+	*/
 }
 
 func (app *App) mountStatic() {
 	static := http.StripPrefix("/static/", http.FileServer(http.Dir("./static/")))
 	app.Router.PathPrefix("/static/").Handler(static)
+}
+
+func (app *App) hasCerts() bool {
+	return (app.TLSCertificate != nil) && (app.TLSPrivateKey != nil)
+}
+
+func (app *App) GetPort() string {
+	return ":" + app.Port
 }

--- a/burrow/server.go
+++ b/burrow/server.go
@@ -67,25 +67,6 @@ func (app *App) serveTLS() (err error) {
 	key := *app.TLSPrivateKey
 	info("Now serving encrypted TLS traffic on port :%s", app.Port)
 	return http.ListenAndServeTLS(port, cert, key, nil)
-	/*
-		// This would be if we wanted to redirect http traffic to https
-		errs := make(chan error)
-		go func() {
-			errs <- http.ListenAndServeTLS(":1443", cert, key, nil)
-		}()
-		go func() {
-			redir := func(w http.ResponseWriter, r *http.Request) {
-				// Don't think this works
-				r.URL.Scheme = "https://"
-				http.Redirect(w, r, r.URL.String(), http.StatusMovedPermanently)
-			}
-			errs <- http.ListenAndServe(":8080", http.HandlerFunc(redir))
-		}()
-		select {
-		case err = <-errs:
-			return
-		}
-	*/
 }
 
 func (app *App) mountStatic() {

--- a/cli.go
+++ b/cli.go
@@ -32,14 +32,23 @@ func client(args []string) {
 			Usage:       "diglet start --mbtiles path/to/tiles",
 			Description: "Starts the diglet server",
 			Action: func(c *cli.Context) {
-				p := c.String("port")
+				port := c.String("port")
 				mbt := c.String("mbtiles")
 				if mbt == "" {
 					cli.ShowSubcommandHelp(c)
 					die("ERROR: --mbtiles flag is required")
 				}
-				server := diglet.MBTServer(mbt, p)
-				server.Run()
+				cert := c.String("cert")
+				key := c.String("key")
+				server := diglet.MBTServer(mbt, port)
+				if (cert != "") && (key != "") {
+					server.RunTLS(&cert, &key)
+				} else if cert != "" || key != "" {
+					cli.ShowSubcommandHelp(c)
+					die("ERROR: Both cert & key are required to serve over TLS/SSL")
+				} else {
+					server.Run()
+				}
 			},
 			Flags: []cli.Flag{
 				cli.StringFlag{
@@ -49,8 +58,15 @@ func client(args []string) {
 				},
 				cli.StringFlag{
 					Name:  "mbtiles",
-					Value: "",
 					Usage: "REQUIRED: Path to mbtiles to serve",
+				},
+				cli.StringFlag{
+					Name:  "cert, tls-certificate",
+					Usage: "Path to .pem TLS Certificate. Both cert & key required to serve HTTPS",
+				},
+				cli.StringFlag{
+					Name:  "key, tls-private-key",
+					Usage: "Path to .pem TLS Private Key. Both cert & key required to serve HTTPS",
 				},
 			},
 		},


### PR DESCRIPTION
Serves HTTPS endpoints if both the certificate and private key are provided via --cert and --key.
